### PR TITLE
Correct OWNERS file to include BZ component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,5 @@ approvers:
 - gnufied
 - bertinatto
 - huffmanca
-components: Storage
-subcomponent: Operators
+component: "Storage"
+subcomponent: "Operators"


### PR DESCRIPTION
This is in response to an email about missing BZ component. This should correct the typo `components` -> `component`, and also surround the field with quotations should that be needed (as all the other OCP repos have this field in quotations).