### PR TITLE
Add cluster ID as extra label for newly created PDs.

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -33,6 +33,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
+            - --extra-labels=${CLUSTER_ID}=owned
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -105,6 +105,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
+            - --extra-labels=${CLUSTER_ID}=owned
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"


### PR DESCRIPTION
Use the new `extra-labels` option introduced in https://github.com/openshift/gcp-pd-csi-driver/pull/11.