### PR TITLE
Bug 1933184: Add maxUnavailable to DaemonSets

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       app: gcp-pd-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -258,6 +258,10 @@ spec:
   selector:
     matchLabels:
       app: gcp-pd-csi-driver-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
To speed up cluster upgrade by allowing more nodes to be updated
simultaneously.