### PR TITLE
Change the disk label name

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -33,7 +33,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
-            - --extra-labels=${CLUSTER_ID}=owned
+            - --extra-labels=kubernetes-io-cluster-${CLUSTER_ID}=owned
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -105,7 +105,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=${LOG_LEVEL}
-            - --extra-labels=${CLUSTER_ID}=owned
+            - --extra-labels=kubernetes-io-cluster-${CLUSTER_ID}=owned
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"


### PR DESCRIPTION
The OpenShift installer already uses labels for instances. They are prefixed with "kubernetes-io-cluster-". Let's use the same label name also for disks for consistency. This patch adds the same prefix as the existing filter expects:

See https://github.com/tsmetana/installer/blob/7e02fe75a583242e4cbb8c60472b105acf7a8266/pkg/destroy/gcp/gcp.go#L183-L185