### PR TITLE
Bug 1951058: Enable multipods capability in e2e tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -26,3 +26,5 @@ DriverInfo:
     controllerExpansion: true
     nodeExpansion: true
     snapshotDataSource: true
+    topology: true
+    multipods: true


### PR DESCRIPTION
GCP PD supports both topology and multipods capabilities.

CC @openshift/storage 
