### PR TITLE
Bug 1972028: Fix number of replicas

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -112,6 +112,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			secretName,
 			secretInformer,
 		),
+		csidrivercontrollerservicecontroller.WithReplicasHook(nodeInformer.Lister()),
 	).WithCSIDriverNodeService(
 		"GCPPDDriverNodeServiceController",
 		assets.ReadFile,


### PR DESCRIPTION
In #30 I forgot to call the function hook that effectively sets the number of replicas of the CSI Controller Deployment.

CC @openshift/storage
