### PR TITLE
Bug 1968253: Start provisioner with controller-publish-readonly option

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -92,6 +92,7 @@ spec:
             - --leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}
             - --leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}
             - --leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}
+            - --controller-publish-readonly
             - --v=${LOG_LEVEL}
           env:
             - name: ADDRESS


### PR DESCRIPTION
Let's make use of the new option that would cause ROX volumes to be published read-only.