### PR TITLE
Bug 2077050: OCP should default to pd-ssd disk type on GCP

### DIFF
--- a/assets/storageclass_ssd.yaml
+++ b/assets/storageclass_ssd.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd-csi
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-ssd
+  replication-type: none
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -71,6 +71,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		assets.ReadFile,
 		[]string{
 			"storageclass.yaml",
+			"storageclass_ssd.yaml",
 			"volumesnapshotclass.yaml",
 			"csidriver.yaml",
 			"controller_sa.yaml",

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -1,5 +1,5 @@
 StorageClass:
-  FromExistingClassName: standard-csi
+  FromExistingClassName: ssd-csi
 SnapshotClass:
   FromName: true
 DriverInfo:


### PR DESCRIPTION
Merge along with [PR](https://github.com/openshift/cluster-storage-operator/pull/273)

cc @openshift/storage 