### PR TITLE
Bug 2098655: gcp cluster rollback fails due to storage failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+	github.com/openshift/library-go v0.0.0-20220502105925-109ae411def1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1
 	k8s.io/apimachinery v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6 h1:HS6brMoum1oJyFriix+Ae3J2FfvK9u9TBqUu+JnG/pc=
-github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
+github.com/openshift/library-go v0.0.0-20220502105925-109ae411def1 h1:JVjvwkstOAFAV1jBsnfW0tYiOgYpqt1f8ly2MVwupQA=
+github.com/openshift/library-go v0.0.0-20220502105925-109ae411def1/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
+	"github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller"
 	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -38,6 +39,7 @@ type CSIControllerSet struct {
 	csiDriverControllerServiceController factory.Controller
 	csiDriverNodeServiceController       factory.Controller
 	serviceMonitorController             factory.Controller
+	csiStorageclassController            factory.Controller
 
 	operatorClient v1helpers.OperatorClientWithFinalizers
 	eventRecorder  events.Recorder
@@ -54,6 +56,7 @@ func (c *CSIControllerSet) Run(ctx context.Context, workers int) {
 		c.csiDriverControllerServiceController,
 		c.csiDriverNodeServiceController,
 		c.serviceMonitorController,
+		c.csiStorageclassController,
 	} {
 		if ctrl == nil {
 			continue
@@ -207,6 +210,25 @@ func (c *CSIControllerSet) WithServiceMonitorController(
 		c.operatorClient,
 		c.eventRecorder,
 	).WithIgnoreNotFoundOnCreate()
+	return c
+}
+
+func (c *CSIControllerSet) WithStorageClassController(
+	name string,
+	assetFunc resourceapply.AssetFunc,
+	file string,
+	kubeClient kubernetes.Interface,
+	namespacedInformerFactory informers.SharedInformerFactory,
+) *CSIControllerSet {
+	c.csiStorageclassController = csistorageclasscontroller.NewCSIStorageClassController(
+		name,
+		assetFunc,
+		file,
+		kubeClient,
+		namespacedInformerFactory,
+		c.operatorClient,
+		c.eventRecorder,
+	)
 	return c
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller/csi_storageclass_controller.go
@@ -1,0 +1,146 @@
+package csistorageclasscontroller
+
+import (
+	"context"
+	operatorapi "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+const (
+	defaultScAnnotationKey = "storageclass.kubernetes.io/is-default-class"
+)
+
+// This Controller deploys a StorageClass provided by CSI driver operator
+// and decides if this StorageClass should be applied as default - if requested.
+// If operator wants to request it's StorageClass to be created as default,
+// the asset file provided to this controller must have defaultScAnnotationKey set to "true".
+// Based on the current StorageClasses in the cluster the controller can decide not
+// to deploy given StorageClass as default if there already is any existing default.
+// When the controller detects there already is a StorageClass with a same name it
+// just copies the default StorageClass annotation from the existing one to prevent
+// overwriting value that user might have manually changed.
+// If the asset file does not have defaultScAnnotationKey set at all, controller
+// just skips any checks and modifications and applies the StorageClass as it is.
+// It produces following Conditions:
+// StorageClassControllerDegraded - failed to apply StorageClass provided
+type CSIStorageClassController struct {
+	name               string
+	assetFunc          resourceapply.AssetFunc
+	file               string
+	kubeClient         kubernetes.Interface
+	storageClassLister v1.StorageClassLister
+	operatorClient     v1helpers.OperatorClient
+	eventRecorder      events.Recorder
+}
+
+func NewCSIStorageClassController(
+	name string,
+	assetFunc resourceapply.AssetFunc,
+	file string,
+	kubeClient kubernetes.Interface,
+	informerFactory informers.SharedInformerFactory,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder) factory.Controller {
+	c := &CSIStorageClassController{
+		name:               name,
+		assetFunc:          assetFunc,
+		file:               file,
+		kubeClient:         kubeClient,
+		storageClassLister: informerFactory.Storage().V1().StorageClasses().Lister(),
+		operatorClient:     operatorClient,
+		eventRecorder:      eventRecorder,
+	}
+
+	return factory.New().WithSync(
+		c.Sync,
+	).ResyncEvery(
+		time.Minute,
+	).WithSyncDegradedOnError(
+		operatorClient,
+	).WithInformers(
+		operatorClient.Informer(),
+		informerFactory.Storage().V1().StorageClasses().Informer(),
+	).ToController(
+		"StorageClassController",
+		eventRecorder,
+	)
+}
+
+func (c *CSIStorageClassController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.V(4).Infof("StorageClassController sync started")
+	defer klog.V(4).Infof("StorageClassController sync finished")
+
+	opSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	if opSpec.ManagementState != operatorapi.Managed {
+		return nil
+	}
+
+	syncErr := c.syncStorageClass(ctx)
+
+	return syncErr
+}
+
+func (c *CSIStorageClassController) syncStorageClass(ctx context.Context) error {
+	expectedScBytes, err := c.assetFunc(c.file)
+	if err != nil {
+		return err
+	}
+
+	expectedSC := resourceread.ReadStorageClassV1OrDie(expectedScBytes)
+
+	existingSCs, err := c.storageClassLister.List(labels.Everything())
+	if err != nil {
+		klog.V(2).Infof("could not list StorageClass objects")
+		return err
+	}
+
+	defaultSCCount := 0
+	annotationKeyPresent := false
+	// Skip the default SC annotation check if it's not in the input/expectedSC.
+	if expectedSC.Annotations != nil && expectedSC.Annotations[defaultScAnnotationKey] != "" {
+		for _, sc := range existingSCs {
+			if sc.Annotations[defaultScAnnotationKey] == "true" && sc.Name != expectedSC.Name {
+				defaultSCCount++
+			}
+			if sc.Name == expectedSC.Name && sc.Annotations != nil {
+				// There already is an SC with same name we intend to apply, copy its annotation.
+				if val, ok := sc.Annotations[defaultScAnnotationKey]; ok {
+					expectedSC.Annotations[defaultScAnnotationKey] = val
+					annotationKeyPresent = true // If there is a key, we need to preserve it, whatever the value is.
+				} else {
+					annotationKeyPresent = false
+				}
+			}
+		}
+		// There already is a default, and it's not set on the SC we intend to apply. Also, if there is any value for
+		// defaultScAnnotationKey do not overwrite it (empty string is a correct value).
+		if defaultSCCount > 0 && !annotationKeyPresent {
+			expectedSC.Annotations[defaultScAnnotationKey] = "false"
+		}
+	}
+
+	_, _, err = resourceapply.ApplyStorageClass(ctx, c.kubeClient.StorageV1(), c.eventRecorder, expectedSC)
+
+	return err
+}
+
+// UpdateConditionFunc returns a func to update a condition.
+func removeConditionFn(condType string) v1helpers.UpdateStatusFunc {
+	return func(oldStatus *operatorapi.OperatorStatus) error {
+		v1helpers.RemoveOperatorCondition(&oldStatus.Conditions, condType)
+		return nil
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -2,6 +2,7 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
@@ -52,10 +53,57 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 		klog.Infof("StorageClass %q changes: %v", required.Name, JSONPatchNoError(existingCopy, requiredCopy))
 	}
 
-	// TODO if provisioner, parameters, reclaimpolicy, or volumebindingmode are different, update will fail so delete and recreate
+	if storageClassNeedsRecreate(existingCopy, requiredCopy) {
+		requiredCopy.ObjectMeta.ResourceVersion = ""
+		err = client.StorageClasses().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+		reportDeleteEvent(recorder, requiredCopy, err, "Deleting StorageClass to re-create it with updated parameters")
+		if err != nil && !apierrors.IsNotFound(err) {
+			return existing, false, err
+		}
+		actual, err := client.StorageClasses().Create(ctx, requiredCopy, metav1.CreateOptions{})
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			// Delete() few lines above did not really delete the object,
+			// the API server is probably waiting for a finalizer removal or so.
+			// Report an error, but something else than "Already exists", because
+			// that would be very confusing - Apply failed because the object
+			// already exists???
+			err = fmt.Errorf("failed to re-create StorageClass %s, waiting for the original object to be deleted", existingCopy.Name)
+		} else if err != nil {
+			err = fmt.Errorf("failed to re-create StorageClass %s: %s", existingCopy.Name, err)
+		}
+		reportCreateEvent(recorder, actual, err)
+		return actual, true, err
+	}
+
+	// Only mutable fields need a change
 	actual, err := client.StorageClasses().Update(ctx, requiredCopy, metav1.UpdateOptions{})
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
+}
+
+func storageClassNeedsRecreate(oldSC, newSC *storagev1.StorageClass) bool {
+	// Based on kubernetes/kubernetes/pkg/apis/storage/validation/validation.go,
+	// these fields are immutable.
+	if !equality.Semantic.DeepEqual(oldSC.Parameters, newSC.Parameters) {
+		return true
+	}
+	if oldSC.Provisioner != newSC.Provisioner {
+		return true
+	}
+
+	// In theory, ReclaimPolicy is always set, just in case:
+	if (oldSC.ReclaimPolicy == nil && newSC.ReclaimPolicy != nil) ||
+		(oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy == nil) {
+		return true
+	}
+	if oldSC.ReclaimPolicy != nil && newSC.ReclaimPolicy != nil && *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
+		return true
+	}
+
+	if !equality.Semantic.DeepEqual(oldSC.VolumeBindingMode, newSC.VolumeBindingMode) {
+		return true
+	}
+	return false
 }
 
 // ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -61,7 +61,7 @@ type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
-	preconfitions          []StaticResourcesPreconditionsFuncType
+	preconditions          []StaticResourcesPreconditionsFuncType
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -106,7 +106,7 @@ func NewStaticResourceController(
 		operatorClient: operatorClient,
 		clients:        clients,
 
-		preconfitions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
+		preconditions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
 
@@ -136,7 +136,7 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 //
 // When the requirement is not met, the controller reports degraded status.
 func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
-	c.preconfitions = append(c.preconfitions, precondition)
+	c.preconditions = append(c.preconditions, precondition)
 	return c
 }
 
@@ -283,7 +283,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 		return nil
 	}
 
-	for _, precondition := range c.preconfitions {
+	for _, precondition := range c.preconditions {
 		ready, err := precondition(ctx)
 		// We don't care about the other preconditions, we just stop on the first one.
 		if !ready {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -213,7 +213,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+# github.com/openshift/library-go v0.0.0-20220502105925-109ae411def1
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client
@@ -234,6 +234,7 @@ github.com/openshift/library-go/pkg/operator/csi/csiconfigobservercontroller
 github.com/openshift/library-go/pkg/operator/csi/csicontrollerset
 github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller
 github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller
+github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller
 github.com/openshift/library-go/pkg/operator/deploymentcontroller
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/genericoperatorclient


### PR DESCRIPTION
Bump library-go so that we include [this](https://github.com/openshift/library-go/pull/1355) change from library-go in gcp driver operator. This should allow changing/re-creating the StorageClass allowing downgrade from 4.11 to 4.10 which now fails because the re-creation is not allowed.

cc @openshift/storage