### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -57,6 +57,8 @@ spec:
               mountPath: /run/udev
             - name: sys
               mountPath: /sys
+            - name: etc-selinux
+              mountPath: /etc/selinux
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -155,3 +157,7 @@ spec:
           hostPath:
             path: /sys
             type: Directory
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate


### PR DESCRIPTION
To support "mount -o context=XYZ", /etc/selinux and /sys/fs/selinux from the host must be present in the CSI driver container.

This PR is different than others, the driver already has `/sys` mounted from the host.

cc @openshift/storage 