### PR TITLE
Add clone test for gcp-pd-csi-driver

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -26,6 +26,7 @@ DriverInfo:
     controllerExpansion: true
     nodeExpansion: true
     snapshotDataSource: true
+    pvcDataSource: true
     topology: true
     multipods: true
     multiplePVsSameID: true


### PR DESCRIPTION
The gcp-pd-csi-driver supports clone from OCP 4.11, so adding clone test.