### PR TITLE
WIP: deployment controller progressing timeout with condition message

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -250,7 +250,7 @@ func withCustomLabels(infraLister configlisters.InfrastructureLister) dc.Deploym
 		labels = append(labels, fmt.Sprintf(ocpDefaultLabelFmt, infra.Status.InfrastructureName))
 		labelsStr := strings.Join(labels, ",")
 		labelsArg := fmt.Sprintf("--extra-labels=%s", labelsStr)
-		klog.V(1).Infof("withCustomLabels: adding extra-labels arg to driver with value %s", labelsStr)
+		klog.V(6).Infof("withCustomLabels: adding extra-labels arg to driver with value %s", labelsStr)
 
 		for i := range deployment.Spec.Template.Spec.Containers {
 			container := &deployment.Spec.Template.Spec.Containers[i]

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -52,6 +52,8 @@ const (
 	// ocpDefaultLabelFmt is the format string for the default label
 	// added to the OpenShift created GCP resources.
 	ocpDefaultLabelFmt = "kubernetes-io-cluster-%s=owned"
+
+	defaultControllerTimeout = 10 * time.Minute
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
@@ -208,6 +210,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces.InformersFor(""),
 		operatorInformers,
 		getKMSKeyHook(operatorInformers.Operator().V1().ClusterCSIDrivers().Lister()),
+	).WithControllerTimeout(
+		"GCPPDDriverControllerServiceController",
+		defaultControllerTimeout,
 	)
 
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -33,6 +33,7 @@ var defaultCacheSyncTimeout = 10 * time.Minute
 // CSIControllerSet contains a set of controllers that are usually used to deploy CSI Drivers.
 type CSIControllerSet struct {
 	logLevelController                   factory.Controller
+	progressingTimeoutController         factory.Controller
 	managementStateController            factory.Controller
 	staticResourcesController            factory.Controller
 	conditionalStaticResourcesController factory.Controller
@@ -51,6 +52,7 @@ type CSIControllerSet struct {
 func (c *CSIControllerSet) Run(ctx context.Context, workers int) {
 	for _, ctrl := range []factory.Controller{
 		c.logLevelController,
+		c.progressingTimeoutController,
 		c.managementStateController,
 		c.staticResourcesController,
 		c.conditionalStaticResourcesController,
@@ -74,6 +76,11 @@ func (c *CSIControllerSet) Run(ctx context.Context, workers int) {
 // WithLogLevelController returns a *ControllerSet with a log level controller initialized.
 func (c *CSIControllerSet) WithLogLevelController() *CSIControllerSet {
 	c.logLevelController = loglevel.NewClusterOperatorLoggingController(c.operatorClient, c.eventRecorder)
+	return c
+}
+
+func (c *CSIControllerSet) WithControllerTimeout(name string, timeout time.Duration) *CSIControllerSet {
+	c.progressingTimeoutController = deploymentcontroller.NewTimeoutController(c.operatorClient, name, timeout, c.eventRecorder)
 	return c
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/deploymentcontroller/deploymenttimeout_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/deploymentcontroller/deploymenttimeout_controller.go
@@ -1,0 +1,67 @@
+package deploymentcontroller
+
+import (
+	"context"
+	"fmt"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/klog/v2"
+	"time"
+)
+
+const (
+	resyncInterval = 1 * time.Minute
+)
+
+type TimeoutController struct {
+	operatorClient v1helpers.OperatorClient
+	name           string
+	timeout        time.Duration
+}
+
+func NewTimeoutController(operatorClient v1helpers.OperatorClient, name string, timeout time.Duration, recorder events.Recorder) factory.Controller {
+	c := &TimeoutController{
+		operatorClient: operatorClient,
+		name:           name,
+		timeout:        timeout,
+	}
+	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ResyncEvery(resyncInterval).ToController("TimeoutController", recorder)
+}
+
+func (c TimeoutController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	_, currentStatus, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		klog.Errorf("Error getting operator status: %v", err)
+		return err
+	}
+
+	operatorCondition := v1helpers.FindOperatorCondition(currentStatus.Conditions, c.name+operatorv1.OperatorStatusTypeProgressing)
+
+	if operatorCondition != nil && operatorCondition.Status == operatorv1.ConditionTrue && operatorCondition.LastTransitionTime.Add(c.timeout).Before(time.Now()) {
+		_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+			Type:    c.name + "ProgressingTimeout" + "Degraded",
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "SyncTimeoutError",
+			Message: fmt.Sprintf("Operator condition %s failed to transition to %s in the last %0.f minutes.", operatorCondition.Type, operatorv1.ConditionFalse, c.timeout.Minutes()),
+		}))
+
+		if updateErr != nil {
+			klog.Warningf("Updating status of %q failed: %v", c.name, updateErr)
+			return updateErr
+		}
+		return nil
+	}
+
+	_, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+		Type:   c.name + "ProgressingTimeout" + "Degraded",
+		Status: operatorv1.ConditionFalse,
+	}))
+	if updateErr != nil {
+		klog.Warningf("Updating status of %q failed: %v", c.name, updateErr)
+		return updateErr
+	}
+
+	return nil
+}


### PR DESCRIPTION
DRAFT

Adds a new controller that will degrade cluster when deployment fails to transition to progressing=false in a certain amount of time.

Tested with 1 minute timeout:

```
$ oc -n openshift-cloud-credential-operator scale --replicas=0 deployment/cloud-credential-operator

$ oc -n openshift-cluster-csi-drivers delete secret/gcp-pd-cloud-credentials

$ oc get clusteroperator/storage
NAME      VERSION          AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
storage   0.0.1-snapshot   True        True          False      2m40s   GCPPDCSIDriverOperatorCRProgressing: GCPPDDriverControllerServiceControllerProgressing: Waiting for Deployment to deploy pods


$ oc get clustercsidriver/pd.csi.storage.gke.io -o yaml
...
  - lastTransitionTime: "2024-01-10T14:42:47Z"
    message: Operator condition GCPPDDriverControllerServiceControllerProgressing
      failed to transition to False in the last 1 minutes.
    reason: SyncTimeoutError
    status: "True"
    type: GCPPDDriverControllerServiceControllerProgressingTimeoutDegraded
...


$ oc get clusteroperator/storage && date
NAME      VERSION          AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
storage   0.0.1-snapshot   True        True          True       6m33s   GCPPDCSIDriverOperatorCRDegraded: GCPPDDriverControllerServiceControllerProgressingTimeoutDegraded: Operator condition GCPPDDriverControllerServiceControllerProgressing failed to transition to False in the last 1 minutes.
Wed Jan 10 15:46:58 CET 2024
```