### PR TITLE
CFE-879: Add resourceTags in Infrastructure to driver args list

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -179,6 +179,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		),
 		csidrivercontrollerservicecontroller.WithReplicasHook(nodeInformer.Lister()),
 		withCustomLabels(infraInformer.Lister()),
+		withCustomResourceTags(infraInformer.Lister()),
 	).WithCSIDriverNodeService(
 		"GCPPDDriverNodeServiceController",
 		assets.ReadFile,
@@ -250,7 +251,7 @@ func withCustomLabels(infraLister configlisters.InfrastructureLister) dc.Deploym
 		labels = append(labels, fmt.Sprintf(ocpDefaultLabelFmt, infra.Status.InfrastructureName))
 		labelsStr := strings.Join(labels, ",")
 		labelsArg := fmt.Sprintf("--extra-labels=%s", labelsStr)
-		klog.V(1).Infof("withCustomLabels: adding extra-labels arg to driver with value %s", labelsStr)
+		klog.V(5).Infof("withCustomLabels: adding extra-labels arg to driver with value %s", labelsStr)
 
 		for i := range deployment.Spec.Template.Spec.Containers {
 			container := &deployment.Spec.Template.Spec.Containers[i]
@@ -258,6 +259,45 @@ func withCustomLabels(infraLister configlisters.InfrastructureLister) dc.Deploym
 				continue
 			}
 			container.Args = append(container.Args, labelsArg)
+		}
+		return nil
+	}
+}
+
+// withCustomResourceTags adds resource tags from infrastructure.status.platformStatus.gcp.resourceTags to the
+// driver command line as --resource-tags=<parent_id>/<tagKey_shortname>/<tagValue_shortname>,...
+func withCustomResourceTags(infraLister configlisters.InfrastructureLister) dc.DeploymentHookFunc {
+	return func(spec *opv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		infra, err := infraLister.Get(globalInfrastructureName)
+		if err != nil {
+			return fmt.Errorf("withCustomResourceTags: failed to fetch global Infrastructure object: %w", err)
+		}
+
+		var tags []string
+		if infra.Status.PlatformStatus != nil &&
+			infra.Status.PlatformStatus.GCP != nil &&
+			infra.Status.PlatformStatus.GCP.ResourceTags != nil {
+			tags = make([]string, len(infra.Status.PlatformStatus.GCP.ResourceTags))
+			for i, tag := range infra.Status.PlatformStatus.GCP.ResourceTags {
+				tags[i] = fmt.Sprintf("%s/%s/%s", tag.ParentID, tag.Key, tag.Value)
+			}
+		}
+
+		if len(tags) <= 0 {
+			klog.V(5).Infof("withCustomResourceTags: user tags not configured, no changes made to driver args")
+			return nil
+		}
+
+		tagsStr := strings.Join(tags, ",")
+		tagsArg := fmt.Sprintf("--extra-tags=%s", tagsStr)
+		klog.V(5).Infof("withCustomResourceTags: adding extra-tags arg to driver with value %s", tagsStr)
+
+		for i := range deployment.Spec.Template.Spec.Containers {
+			container := &deployment.Spec.Template.Spec.Containers[i]
+			if container.Name != "csi-driver" {
+				continue
+			}
+			container.Args = append(container.Args, tagsArg)
 		}
 		return nil
 	}

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -142,3 +142,132 @@ func TestWithCustomLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestWithCustomResourceTags(t *testing.T) {
+	infraObj := &v1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: v1.InfrastructureStatus{
+			InfrastructureName: "test-sgdh7",
+			PlatformStatus: &v1.PlatformStatus{
+				GCP: &v1.GCPPlatformStatus{
+					ProjectID: "test",
+					Region:    "test",
+				},
+			},
+		},
+	}
+
+	tmplDeployObj := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "csi-driver",
+							Image: "example.io/example-csi-driver",
+							Args: []string{
+								"--endpoint=$(CSI_ENDPOINT)",
+								"--logtostderr",
+								"--v=2",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+									Value: "/etc/cloud-sa/service_account.json",
+								},
+								{
+									Name:  "CSI_ENDPOINT",
+									Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+								},
+							},
+						},
+						{
+							Name:  "test-driver",
+							Image: "example.io/example-test-driver",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		tags          []v1.GCPResourceTag
+		expArgList    string
+		createInfraCR bool
+		wantErr       bool
+	}{
+		{
+			name:          "user tags not configured",
+			tags:          []v1.GCPResourceTag{},
+			expArgList:    "",
+			createInfraCR: true,
+			wantErr:       false,
+		},
+		{
+			name: "user tags configured",
+			tags: []v1.GCPResourceTag{
+				{
+					ParentID: "openshift",
+					Key:      "key1",
+					Value:    "value1",
+				},
+				{
+					ParentID: "openshift",
+					Key:      "key2",
+					Value:    "value2",
+				},
+				{
+					ParentID: "openshift",
+					Key:      "key3",
+					Value:    "value3",
+				},
+			},
+			expArgList:    "--extra-tags=openshift/key1/value1,openshift/key2/value2,openshift/key3/value3",
+			createInfraCR: true,
+			wantErr:       false,
+		},
+		{
+			name:          "Infrastructure CR does not exist",
+			tags:          []v1.GCPResourceTag{},
+			expArgList:    "",
+			createInfraCR: false,
+			wantErr:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0)
+			if test.createInfraCR {
+				infraObj.Status.PlatformStatus.GCP.ResourceTags = test.tags
+				objs = append(objs, infraObj)
+			}
+			configClient := fakeconfig.NewSimpleClientset(objs...)
+			configInformerFactory := configinformers.NewSharedInformerFactory(configClient, 0)
+			if test.createInfraCR {
+				configInformerFactory.Config().V1().Infrastructures().Informer().GetIndexer().Add(infraObj)
+			}
+
+			deployment := tmplDeployObj.DeepCopy()
+			updDeployment := tmplDeployObj.DeepCopy()
+			if test.expArgList != "" {
+				updDeployment.Spec.Template.Spec.Containers[0].Args = append(
+					updDeployment.Spec.Template.Spec.Containers[0].Args,
+					test.expArgList,
+				)
+			}
+
+			err := withCustomResourceTags(configInformerFactory.Config().V1().Infrastructures().Lister())(nil, deployment)
+			if (err != nil) != test.wantErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !equality.Semantic.DeepEqual(deployment, updDeployment) {
+				t.Errorf("unexpected deployment want: %+v got: %+v", updDeployment, deployment)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PR has the changes for https://github.com/openshift/enhancements/pull/1217 proposed to support GCP tags in OCP, which requires gcp-pd-csi-driver-operator to add gcp resourceTags available in the status sub-resource of infrastructure CR, to the gcp resources created by the driver.