### PR TITLE
STOR-1819: Add manifest with OCP specific test config

### DIFF
--- a/test/e2e/ocp-manifest.yaml
+++ b/test/e2e/ocp-manifest.yaml
@@ -1,0 +1,4 @@
+Driver: pd.csi.storage.gke.io
+LUNStressTest:
+  PodsTotal: 260
+  Timeout: "30m" # The test needs ~10 min in ideal conditions.


### PR DESCRIPTION
The LUN stress test finished under 10 minutes few times, adding 20 minutes as a buffer.

cc @openshift/storage 