### PR TITLE
OCPBUGS-48100: Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build and run the operator locally:
 
 ```shell
 # Create only the resources the operator needs to run via CLI
-oc apply -f https://raw.githubusercontent.com/openshift/cluster-storage-operator/master/assets/csidriveroperators/gcp-pd/08_cr.yaml
+oc apply -f https://raw.githubusercontent.com/openshift/cluster-storage-operator/main/assets/csidriveroperators/gcp-pd/08_cr.yaml
 
 # Build the operator
 make


### PR DESCRIPTION
Update master branch to main

/cc @openshift/storage 