### PR TITLE
STOR-2798: Add test e2e manifest and VolumeSnapshotClass for image volumeSnapshotClass CSI tests

### DIFF
--- a/test/e2e/image-snapshot-manifest.yaml
+++ b/test/e2e/image-snapshot-manifest.yaml
@@ -1,7 +1,7 @@
 StorageClass:
   FromExistingClassName: ssd-csi
 SnapshotClass:
-  FromName: true
+  FromFile: images-volumesnapshotclass.yaml
 DriverInfo:
   Name: pd.csi.storage.gke.io
   SupportedFsType:

--- a/test/e2e/images-volumesnapshotclass.yaml
+++ b/test/e2e/images-volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: test-csi-gce-pd-vsc-images
+driver: pd.csi.storage.gke.io
+deletionPolicy: Delete
+parameters:
+  snapshot-type: images


### PR DESCRIPTION
## Summary

This change adds optional CSI test driver assets so snapshot tests can exercise image snapshots (snapshot-type: images) without altering the default driver manifest and enables upstream Kubernetes volume snapshot stress tests for GCP PD CSI e2e driver manifests

### What's added

- test/e2e/images-volumesnapshotclass.yaml — a VolumeSnapshotClass for pd.csi.storage.gke.io with `parameters.snapshot-type: images`, matching the behavior of the operator’s image snapshot class asset.

- test/e2e/image-snapshot-manifest.yaml — same layout as test/e2e/manifest.yaml (storage class, driver info, capabilities, timeouts), except SnapshotClass is loaded from the YAML above via FromFile.

- Enable upstream Kubernetes volume snapshot stress tests for GCP PD CSI e2e driver manifests, and extend e2e timeouts only for the image snapshot manifest where create / restore / delete paths are slower than defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end test configurations for volume snapshot functionality, including test parameters for pod count and snapshot operations limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->