### PR TITLE
STOR-2798: Update image-snapshot CSI manifest to use operator provided imageVolumeSnapshotClass

### DIFF
--- a/test/e2e/image-snapshot-manifest.yaml
+++ b/test/e2e/image-snapshot-manifest.yaml
@@ -1,7 +1,7 @@
 StorageClass:
   FromExistingClassName: ssd-csi
 SnapshotClass:
-  FromFile: images-volumesnapshotclass.yaml
+  FromExistingClassName: csi-gce-pd-vsc-images
 DriverInfo:
   Name: pd.csi.storage.gke.io
   SupportedFsType:

--- a/test/e2e/images-volumesnapshotclass.yaml
+++ b/test/e2e/images-volumesnapshotclass.yaml
@@ -1,8 +1,0 @@
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshotClass
-metadata:
-  name: test-csi-gce-pd-vsc-images
-driver: pd.csi.storage.gke.io
-deletionPolicy: Delete
-parameters:
-  snapshot-type: images


### PR DESCRIPTION
## Summary

This updates test/e2e/image-snapshot-manifest.yaml, aligned with the default CSI driver manifest (storage class, DriverInfo, capabilities, timeouts) but wired for image snapshots by setting SnapshotClass.FromExistingClassName to csi-gce-pd-vsc-images, the same VolumeSnapshotClass name the operator applies from assets/volumesnapshotclass_images.yaml.

Jobs or local runs that need image snapshot behavior can point TEST_CSI_DRIVER_FILES at this file instead of manifest.yaml, without relying on FromFile (which uses os.ReadFile on a bare filename and breaks when the test process cwd does not contain the YAML). No separate snapshot-class YAML is checked in; the cluster must already expose that VolumeSnapshotClass (normal when the GCP PD CSI operator and snapshot APIs are installed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated e2e test configuration to reference existing Kubernetes snapshot class by name instead of external file definition.
  * Simplified test infrastructure for image snapshot class resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->