### PR TITLE
OCPBUGS-85023: Add test e2e manifest for images volumeSnapshotClass CSI tests

### DIFF
--- a/test/e2e/image-snapshot-manifest.yaml
+++ b/test/e2e/image-snapshot-manifest.yaml
@@ -1,7 +1,7 @@
 StorageClass:
   FromExistingClassName: ssd-csi
 SnapshotClass:
-  FromName: true
+  FromExistingClassName: csi-gce-pd-vsc-images
 DriverInfo:
   Name: pd.csi.storage.gke.io
   SupportedFsType:


### PR DESCRIPTION
## Summary

This is manual backport of PRs: 
https://github.com/openshift/gcp-pd-csi-driver-operator/pull/178
https://github.com/openshift/gcp-pd-csi-driver-operator/pull/179 

### What's added

- test/e2e/image-snapshot-manifest.yaml — same layout as test/e2e/manifest.yaml (storage class, driver info, capabilities, timeouts), except SnapshotClass is loaded from the YAML above via FromFile.

- Enable upstream Kubernetes volume snapshot stress tests for GCP PD CSI e2e driver manifests
