### PR TITLE
[WIP] OCPBUGS-78592: create init container to wait for kubernetes api to be ready

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -43,6 +43,45 @@ spec:
                   matchLabels:
                     app: gcp-pd-csi-driver-controller
                 topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: wait-for-api
+          image: ${PROVISIONER_IMAGE}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for Kubernetes API to be ready..."
+              KUBE_API_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+              SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+              RETRY_COUNT=0
+              MAX_RETRIES=300 # ~10 minutes of waiting for API to be ready
+
+              until [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; do
+                if curl -sf --max-time 3 \
+                  -H "Authorization: Bearer ${SA_TOKEN}" \
+                  --cacert "${CA_CERT}" \
+                  "${KUBE_API_SERVER}/readyz" > /dev/null 2>&1; then
+                  echo "Kubernetes API is ready"
+                  exit 0
+                fi
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                sleep 2
+              done
+
+              echo "ERROR: Kubernetes API did not become ready within timeout"
+              exit 1
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 1m
+            limits:
+              memory: 20Mi
+              cpu: 10m
       containers:
         - name: csi-driver
           securityContext:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -134,11 +134,35 @@ spec:
             readOnlyRootFilesystem: true
           image: ${NODE_DRIVER_REGISTRAR_IMAGE}
           imagePullPolicy: IfNotPresent
-          args:
-            - --csi-address=$(ADDRESS)
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --http-endpoint=:10303
-            - --v=${LOG_LEVEL}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for CSI driver socket to be ready..."
+              SOCKET_PATH="/csi/csi.sock"
+              RETRY_COUNT=0
+              MAX_RETRIES=60  # 2 minutes
+
+              until [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; do
+                if [ -S "${SOCKET_PATH}" ]; then
+                  echo "CSI driver socket is ready"
+                  break
+                fi
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                sleep 2
+              done
+
+              if [ ! -S "${SOCKET_PATH}" ]; then
+                echo "ERROR: CSI driver socket did not become ready within timeout"
+                exit 1
+              fi
+
+              exec /csi-node-driver-registrar \
+                --csi-address=$(ADDRESS) \
+                --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH) \
+                --http-endpoint=:10303 \
+                --v=${LOG_LEVEL}
           lifecycle:
             preStop:
               exec:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -31,6 +31,45 @@ spec:
         - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
+      initContainers:
+        - name: wait-for-api
+          image: ${NODE_DRIVER_REGISTRAR_IMAGE}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for Kubernetes API to be ready..."
+              KUBE_API_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+              SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+              RETRY_COUNT=0
+              MAX_RETRIES=300 # ~10 minutes of waiting for API to be ready
+
+              until [ ${RETRY_COUNT} -ge ${MAX_RETRIES} ]; do
+                if curl -sf --max-time 3 \
+                  -H "Authorization: Bearer ${SA_TOKEN}" \
+                  --cacert "${CA_CERT}" \
+                  "${KUBE_API_SERVER}/readyz" > /dev/null 2>&1; then
+                  echo "Kubernetes API is ready"
+                  exit 0
+                fi
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                sleep 2
+              done
+
+              echo "ERROR: Kubernetes API did not become ready within timeout"
+              exit 1
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 1m
+            limits:
+              memory: 20Mi
+              cpu: 10m
       containers:
         - name: csi-driver
           securityContext:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pods now wait for the Kubernetes API to be ready before starting, and node-side components wait for the CSI socket before launching, reducing startup race conditions and improving reliability.
* **Chores**
  * Containers enforce read-only root filesystem and explicit CPU/memory requests/limits for improved security and resource stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->