### PR TITLE
OCPBUGS-87867: [5.0] VolumeSnapshot snapshot-c9v52 is not ready within 5m0s…

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -31,7 +31,7 @@ DriverInfo:
     multipods: true
     multiplePVsSameID: true
   VolumeSnapshotStressTestOptions:
-    NumPods: 2
-    NumSnapshots: 5
+    NumPods: 5
+    NumSnapshots: 2
 Timeouts:
   DataSourceProvision: 10m


### PR DESCRIPTION
The intermittent failures are caused by GCP PD's per-volume snapshot serialization combined with a test configuration that concentrates too many snapshot requests on too few volumes. The ratio was changed to do less snapshots on more volumes, the number of created snapshosts remain the same.