### PR TITLE
OCPBUGS-86574: VolumeSnapshot snapshot-c9v52 is not ready within 5m0s…

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -31,7 +31,7 @@ DriverInfo:
     multipods: true
     multiplePVsSameID: true
   VolumeSnapshotStressTestOptions:
-    NumPods: 2
-    NumSnapshots: 5
+    NumPods: 5
+    NumSnapshots: 2
 Timeouts:
   DataSourceProvision: 10m


### PR DESCRIPTION
Backport of OCPBUGS-87867 to release-4.22