### PR TITLE
[4.21] OCPBUGS-97960: no-op OWNERS change to trigger postsubmit jobs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,6 @@ approvers:
 - dobsonj
 - RomanBednar
 - mpatlasov
-- rhrmo
 - dfajmon
+- rhrmo
 component: "Storage / Operators"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-97960

See the findings in https://redhat.atlassian.net/browse/OCPBUGS-94091 -- this PR aims to introduce a no-op change to trigger the postsubmit job for the 4.21 branch to generate a new build manifest for the `gcp-pd-csi-driver-operator-test` image.

/cc @openshift/storage
