### PR TITLE
OCPBUGS-99490: Fix SCC RBAC race during controller startup

### DIFF
--- a/pkg/operator/scchook.go
+++ b/pkg/operator/scchook.go
@@ -1,0 +1,51 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/gcp-pd-csi-driver-operator/assets"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+)
+
+// sccPrerequisiteAssets lists ServiceAccounts and SCC RBAC that must exist
+// before CSIControllerSet.Run starts the Deployment/DaemonSet controllers.
+// Without this, the Deployment controller can create pods before the
+// StaticResourcesController applies the ClusterRole+Binding, causing SCC
+// admission to deny pod creation (hostnetwork-v2 / privileged).
+var sccPrerequisiteAssets = []string{
+	"controller_sa.yaml",
+	"node_sa.yaml",
+	"rbac/hostnetwork_role.yaml",
+	"rbac/controller_hostnetwork_binding.yaml",
+	"rbac/privileged_role.yaml",
+	"rbac/node_privileged_binding.yaml",
+}
+
+func ensureSCCPrerequisites(ctx context.Context, kubeClient kubernetes.Interface, recorder events.Recorder) error {
+	klog.Info("Applying SCC prerequisite resources before starting CSI controllers")
+	results := resourceapply.ApplyDirectly(
+		ctx,
+		resourceapply.NewKubeClientHolder(kubeClient),
+		recorder,
+		resourceapply.NewResourceCache(),
+		assets.ReadFile,
+		sccPrerequisiteAssets...,
+	)
+	var errs []error
+	for _, result := range results {
+		if result.Error != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", result.File, result.Error))
+			continue
+		}
+		klog.V(2).Infof("Applied SCC prerequisite %s (changed=%v)", result.File, result.Changed)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to apply SCC prerequisites: %v", errs)
+	}
+	return nil
+}

--- a/pkg/operator/scchook_test.go
+++ b/pkg/operator/scchook_test.go
@@ -1,0 +1,80 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestEnsureSCCPrerequisites(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+	if err := ensureSCCPrerequisites(ctx, client, recorder); err != nil {
+		t.Fatalf("ensureSCCPrerequisites failed: %v", err)
+	}
+
+	checks := []struct {
+		name  string
+		check func() error
+	}{
+		{
+			name: "controller service account",
+			check: func() error {
+				_, err := client.CoreV1().ServiceAccounts(defaultNamespace).Get(ctx, "gcp-pd-csi-driver-controller-sa", metav1.GetOptions{})
+				return err
+			},
+		},
+		{
+			name: "node service account",
+			check: func() error {
+				_, err := client.CoreV1().ServiceAccounts(defaultNamespace).Get(ctx, "gcp-pd-csi-driver-node-sa", metav1.GetOptions{})
+				return err
+			},
+		},
+		{
+			name: "hostnetwork role",
+			check: func() error {
+				_, err := client.RbacV1().ClusterRoles().Get(ctx, "gcp-pd-hostnetwork-role", metav1.GetOptions{})
+				return err
+			},
+		},
+		{
+			name: "controller hostnetwork binding",
+			check: func() error {
+				_, err := client.RbacV1().ClusterRoleBindings().Get(ctx, "gcp-pd-controller-hostnetwork-binding", metav1.GetOptions{})
+				return err
+			},
+		},
+		{
+			name: "privileged role",
+			check: func() error {
+				_, err := client.RbacV1().ClusterRoles().Get(ctx, "gcp-pd-privileged-role", metav1.GetOptions{})
+				return err
+			},
+		},
+		{
+			name: "node privileged binding",
+			check: func() error {
+				_, err := client.RbacV1().ClusterRoleBindings().Get(ctx, "gcp-pd-node-privileged-binding", metav1.GetOptions{})
+				return err
+			},
+		},
+	}
+	for _, c := range checks {
+		if err := c.check(); err != nil {
+			t.Errorf("%s missing after ensureSCCPrerequisites: %v", c.name, err)
+		}
+	}
+
+	// Idempotent: second call must also succeed.
+	if err := ensureSCCPrerequisites(ctx, client, recorder); err != nil {
+		t.Fatalf("ensureSCCPrerequisites second call failed: %v", err)
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -146,17 +146,19 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces,
 		assets.ReadFile,
 		[]string{
-			"csidriver.yaml",
+			// SCC prerequisites first: SAs and their SCC bindings must be
+			// applied before the Deployment/DaemonSet controllers create pods.
 			"controller_sa.yaml",
-			"controller_pdb.yaml",
 			"node_sa.yaml",
-			"service.yaml",
-			"cabundle_cm.yaml",
-			"rbac/main_attacher_binding.yaml",
 			"rbac/privileged_role.yaml",
 			"rbac/hostnetwork_role.yaml",
 			"rbac/controller_hostnetwork_binding.yaml",
 			"rbac/node_privileged_binding.yaml",
+			"csidriver.yaml",
+			"controller_pdb.yaml",
+			"service.yaml",
+			"cabundle_cm.yaml",
+			"rbac/main_attacher_binding.yaml",
 			"rbac/main_provisioner_binding.yaml",
 			"rbac/volumesnapshot_reader_provisioner_binding.yaml",
 			"rbac/volumeattributesclass_reader_provisioner_binding.yaml",
@@ -283,6 +285,10 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	go dynamicInformers.Start(ctx.Done())
 	go configInformers.Start(ctx.Done())
 	go operatorInformers.Start(ctx.Done())
+
+	if err := ensureSCCPrerequisites(ctx, kubeClient, controllerConfig.EventRecorder); err != nil {
+		return err
+	}
 
 	klog.Info("Starting controllerset")
 	go csiControllerSet.Run(ctx, 1)


### PR DESCRIPTION
CSIControllerSet.Run() starts all controllers as parallel goroutines
with no ordering guarantee. The Deployment controller can create pods
before StaticResourcesController applies the hostnetwork-v2 ClusterRole
and ClusterRoleBinding, causing SCC admission to deny pod creation.
This produces FailedCreate events that fail the origin Early SCC e2e
test.

Fix by pre-applying SCC prerequisite resources (ServiceAccounts and
their SCC bindings) synchronously before starting the controller set,
and reordering the static resources list so SCC prerequisites are
applied first on every subsequent sync cycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured required security and access resources are installed before CSI controller components start.
  * Improved error reporting when prerequisite resources cannot be applied.
  * Made prerequisite installation safely repeatable without creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->