### PR TITLE
STOR-3090: Enable pod-delete-after-umount CSI suite for gcp-pd driver OCP manifest

### DIFF
--- a/test/e2e/ocp-manifest.yaml
+++ b/test/e2e/ocp-manifest.yaml
@@ -1,4 +1,5 @@
 Driver: pd.csi.storage.gke.io
+PodDeleteAfterUmountTest: true
 LUNStressTest:
   PodsTotal: 260
   Timeout: "30m" # The test needs ~10 min in ideal conditions.


### PR DESCRIPTION
## Summary

Adds PodDeleteAfterUmountTest: true to OpenShift CSI driver config manifests for:

`test/e2e/ocp-manifest.yaml`

This enables the 'OpenShift CSI extended - Pod delete after umount suite' for gcp-pd driver, aligning test manifest with the new origin test-gating flag introduced in https://github.com/openshift/origin/pull/31488.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled the pod deletion after unmount end-to-end test in the OCP test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->